### PR TITLE
add generalized content selection

### DIFF
--- a/lib/components/content_selection/content_selector.dart
+++ b/lib/components/content_selection/content_selector.dart
@@ -4,35 +4,115 @@ import 'package:helpwave/components/content_selection/list_entry.dart';
 import 'package:helpwave/components/content_selection/list_search.dart';
 import 'package:helpwave/styling/constants.dart';
 
+/// Manages and updates a map of entries with a build in search function
+///
+/// IMPORTANT: If [selectionItems] is omitted or Empty the selection wont be displayed
+///
+/// See also [ListEntry],[ListSearch]
+///
+/// Example with select:
+///
+/// ```dart
+/// ContentSelector(
+///   title: "Weather Stations",
+///   icon: Icon(Icons.ac_unit),
+///   selectionItems: [{"weather": "cold"},{"weather": "warm"}, {"weather": "hot"}],
+///   onChangedList: print,
+///   valueToString: (value) => value["weather"]!,
+///   loadAsyncSearchOptions: (searched, ignoreList) async {
+///     String searchInLower = searched.toLowerCase();
+///     List < String > result = [];
+///     List < String > filteredSearchOptions = ["Louisiana","New York","Tokyo","Berlin"];
+///     filteredSearchOptions
+///       .retainWhere((element) => !ignoreList.contains(element));
+///     for (var element in filteredSearchOptions) {
+///       if (!filteredSearchOptions.contains(searched) &&
+///           element.toLowerCase().startsWith(searchInLower)) {
+///         result.add(element);
+///       }
+///     }
+///     return result;
+///   },
+/// )
+/// ```
+///
+/// Example without select:
+///  - IMPORTANT: omit [selectionItems] to not display a SelectButton here
+///
+/// ```dart
+/// ContentSelector < int >(
+///   selectionDefaultValue:0,
+/// )
+/// ```
 class ContentSelector<V> extends StatefulWidget {
-  final String title;
-  final Icon icon;
+  /// The displayed Title of the expandable Header of the List
+  final String? title;
+
+  /// The icon displayed at beginning of the Header
+  final Icon? icon;
+
+  /// The Map with the initial values
   final Map<String, V> initialValues;
-  final void Function(Map<String, V> map) changedList;
+
+  /// called when the entries are updated and returns the updated map
+  final void Function(Map<String, V> map)? onChangedList;
+
+  /// The Left Indentation of the Entries in regard to the Header
   final double columLeftPadding;
-  final String? selectionLabelText;
-  final List<V> selectionItems;
+
+  /// The Default Value for the selection when adding a new Entry
+  final V? selectionDefaultValue;
+
+  // -- SEARCH --
+  /// The Title displayed in the AppBar of the Search
   final String? searchTitle;
+
+  /// The List of SearchItems that should be ignored
   final List<String>? searchIgnoreList;
-  final List<String>? searchOptions;
+
+  /// The List of all Items for the Search
+  final List<String>? searchItems;
+
+  /// Custom builder for displaying a single search result
   final Widget Function(BuildContext context, String result)?
       searchResultTileBuilder;
+
+  /// This Function returns the list of search results for [searched]
   final Future<List<String>> Function(String searched, List<String> ignoreList)?
       loadAsyncSearchOptions;
-  final V? selectionDefaultValue;
+
+  /// The name of the searched Elements e.g. Medication, Name or Color
+  final String? searchElementName;
+
+  /// Allow adding user input not found in the search list
   final bool allowSelectAnyWay;
+
+  // -- SELECT --
+  /// Maps the value to a displayable String for the Selection
+  /// IMPORTANT: Overwritten by [selectValueItemBuilder]
   final String Function(V value)? valueToString;
+
+  /// The width of the Select
   final double? selectWidth;
+
+  /// A Custom builder for the DropDownItems in the select
+  /// IMPORTANT: Overwrites [valueToString]
   final DropdownMenuItem<V> Function(V value, String name)?
       selectValueItemBuilder;
-  final String? searchElementName;
+
+  /// The LabelText of the Selection Drop-Down
+  final String? selectionLabelText;
+
+  /// The items of the Selection
+  /// IMPORTANT: If omitted or Empty the selection wont be displayed
+  final List<V> selectionItems;
 
   const ContentSelector({
     super.key,
-    required this.title,
-    required this.icon,
-    required this.selectionItems,
-    required this.changedList,
+    this.onChangedList,
+    this.selectionItems = const [],
+    this.title,
+    this.icon = const Icon(Icons.list),
     this.selectWidth,
     this.valueToString,
     this.selectionLabelText,
@@ -43,7 +123,7 @@ class ContentSelector<V> extends StatefulWidget {
     this.columLeftPadding = distanceDefault,
     this.searchTitle,
     this.searchIgnoreList,
-    this.searchOptions,
+    this.searchItems,
     this.searchResultTileBuilder,
     this.loadAsyncSearchOptions,
     this.searchElementName,
@@ -67,8 +147,11 @@ class _ContentSelectorState<V> extends State<ContentSelector<V>> {
 
   @override
   Widget build(BuildContext context) {
-    assert(
-        widget.selectValueItemBuilder != null || widget.valueToString != null);
+    assert(widget.selectionItems.isEmpty ||
+        widget.selectValueItemBuilder != null ||
+        widget.valueToString != null ||
+        (widget.selectionItems.isNotEmpty ||
+            widget.selectionDefaultValue != null));
     List<Widget> children = <Widget>[];
     if (isExpanded) {
       currentSelection.forEach(
@@ -77,22 +160,26 @@ class _ContentSelectorState<V> extends State<ContentSelector<V>> {
             labelText: widget.selectionLabelText ?? "",
             name: key,
             value: value,
-            allValues: widget.selectionItems,
+            items: widget.selectionItems,
             valueToString: widget.valueToString,
             selectWidthCustom: widget.selectWidth,
             selectValueItemBuilder: widget.selectValueItemBuilder,
-            deleteClicked: (deletedValue) {
+            onDeleteClicked: (deletedValue) {
               setState(() {
                 currentSelection.remove(deletedValue);
               });
-              widget.changedList(currentSelection);
+              if (widget.onChangedList != null) {
+                widget.onChangedList!(currentSelection);
+              }
             },
-            changedSelection: (name, value) {
+            onChangedSelection: (name, value) {
               setState(() {
                 currentSelection.update(name, (_) => value,
                     ifAbsent: () => value);
               });
-              widget.changedList(currentSelection);
+              if (widget.onChangedList != null) {
+                widget.onChangedList!(currentSelection);
+              }
             },
           ),
         ),
@@ -106,9 +193,11 @@ class _ContentSelectorState<V> extends State<ContentSelector<V>> {
                 builder: (context) => ListSearch<String>(
                   title: widget.searchTitle ??
                       AppLocalizations.of(context)!.listSearch,
-                  ignoreList:
-                      widget.searchIgnoreList ?? currentSelection.keys.toList(),
-                  items: widget.searchOptions ?? [],
+                  ignoreList: widget.searchIgnoreList != null
+                      ? widget.searchIgnoreList! +
+                          currentSelection.keys.toList()
+                      : currentSelection.keys.toList(),
+                  items: widget.searchItems ?? [],
                   resultTileBuilder: widget.searchResultTileBuilder,
                   elementToString: (String t) => t,
                   asyncFilteredSearchOptions: widget.loadAsyncSearchOptions,
@@ -123,7 +212,9 @@ class _ContentSelectorState<V> extends State<ContentSelector<V>> {
                         widget.selectionDefaultValue ??
                         widget.selectionItems[0]);
               });
-              widget.changedList(currentSelection);
+              if (widget.onChangedList != null) {
+                widget.onChangedList!(currentSelection);
+              }
             });
           },
           icon: const Icon(Icons.add),
@@ -134,7 +225,7 @@ class _ContentSelectorState<V> extends State<ContentSelector<V>> {
     return Column(
       children: [
         ListTile(
-          title: Text(widget.title),
+          title: Text(widget.title ?? AppLocalizations.of(context)!.list),
           subtitle: Text(
               "${currentSelection.length} ${AppLocalizations.of(context)!.entries}"),
           leading: widget.icon,

--- a/lib/components/content_selection/content_selector.dart
+++ b/lib/components/content_selection/content_selector.dart
@@ -18,6 +18,7 @@ import 'package:helpwave/styling/constants.dart';
 ///   icon: Icon(Icons.ac_unit),
 ///   selectionItems: [{"weather": "cold"},{"weather": "warm"}, {"weather": "hot"}],
 ///   onChangedList: print,
+///   equalityCheck: (value1, value2) => value1["weather"] == value2["weather"],
 ///   valueToString: (value) => value["weather"]!,
 ///   loadAsyncSearchOptions: (searched, ignoreList) async {
 ///     String searchInLower = searched.toLowerCase();
@@ -107,6 +108,9 @@ class ContentSelector<V> extends StatefulWidget {
   /// IMPORTANT: If omitted or Empty the selection wont be displayed
   final List<V> selectionItems;
 
+  /// Some more Complex Objects cause issues with the native dropDown
+  final bool Function(V value1, V value2)? equalityCheck;
+
   const ContentSelector({
     super.key,
     this.onChangedList,
@@ -127,6 +131,7 @@ class ContentSelector<V> extends StatefulWidget {
     this.searchResultTileBuilder,
     this.loadAsyncSearchOptions,
     this.searchElementName,
+    this.equalityCheck,
   });
 
   @override
@@ -156,7 +161,7 @@ class _ContentSelectorState<V> extends State<ContentSelector<V>> {
     if (isExpanded) {
       currentSelection.forEach(
         (key, value) => children.add(
-          ListEntry(
+          ListEntry<V>(
             labelText: widget.selectionLabelText ?? "",
             name: key,
             value: value,
@@ -164,6 +169,7 @@ class _ContentSelectorState<V> extends State<ContentSelector<V>> {
             valueToString: widget.valueToString,
             selectWidthCustom: widget.selectWidth,
             selectValueItemBuilder: widget.selectValueItemBuilder,
+            equalityCheck: widget.equalityCheck,
             onDeleteClicked: (deletedValue) {
               setState(() {
                 currentSelection.remove(deletedValue);

--- a/lib/components/content_selection/content_selector.dart
+++ b/lib/components/content_selection/content_selector.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:helpwave/components/content_selection/list_entry.dart';
+import 'package:helpwave/components/content_selection/list_search.dart';
+import 'package:helpwave/styling/constants.dart';
+
+class ContentSelector<V> extends StatefulWidget {
+  final String title;
+  final Icon icon;
+  final Map<String, V> initialValues;
+  final void Function(Map<String, V> map) changedList;
+  final double columLeftPadding;
+  final String? selectionLabelText;
+  final List<V> selectionItems;
+  final String? searchTitle;
+  final List<String>? searchIgnoreList;
+  final List<String>? searchOptions;
+  final Widget Function(BuildContext context, String result)?
+      searchResultTileBuilder;
+  final Future<List<String>> Function(String searched, List<String> ignoreList)?
+      loadAsyncSearchOptions;
+  final V? selectionDefaultValue;
+  final bool allowSelectAnyWay;
+  final String Function(V value)? valueToString;
+  final double? selectWidth;
+  final DropdownMenuItem<V> Function(V value, String name)?
+      selectValueItemBuilder;
+  final String? searchElementName;
+
+  const ContentSelector({
+    super.key,
+    required this.title,
+    required this.icon,
+    required this.selectionItems,
+    required this.changedList,
+    this.selectWidth,
+    this.valueToString,
+    this.selectionLabelText,
+    this.selectionDefaultValue,
+    this.selectValueItemBuilder,
+    this.allowSelectAnyWay = true,
+    this.initialValues = const {},
+    this.columLeftPadding = distanceDefault,
+    this.searchTitle,
+    this.searchIgnoreList,
+    this.searchOptions,
+    this.searchResultTileBuilder,
+    this.loadAsyncSearchOptions,
+    this.searchElementName,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _ContentSelectorState<V>();
+}
+
+class _ContentSelectorState<V> extends State<ContentSelector<V>> {
+  bool isExpanded = false;
+  Map<String, V> currentSelection = <String, V>{};
+
+  @override
+  void initState() {
+    super.initState();
+    widget.initialValues.forEach((key, value) {
+      currentSelection.update(key, (_) => value, ifAbsent: () => value);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    assert(
+        widget.selectValueItemBuilder != null || widget.valueToString != null);
+    List<Widget> children = <Widget>[];
+    if (isExpanded) {
+      currentSelection.forEach(
+        (key, value) => children.add(
+          ListEntry(
+            labelText: widget.selectionLabelText ?? "",
+            name: key,
+            value: value,
+            allValues: widget.selectionItems,
+            valueToString: widget.valueToString,
+            selectWidthCustom: widget.selectWidth,
+            selectValueItemBuilder: widget.selectValueItemBuilder,
+            deleteClicked: (deletedValue) {
+              setState(() {
+                currentSelection.remove(deletedValue);
+              });
+              widget.changedList(currentSelection);
+            },
+            changedSelection: (name, value) {
+              setState(() {
+                currentSelection.update(name, (_) => value,
+                    ifAbsent: () => value);
+              });
+              widget.changedList(currentSelection);
+            },
+          ),
+        ),
+      );
+      children.add(
+        IconButton(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => ListSearch<String>(
+                  title: widget.searchTitle ??
+                      AppLocalizations.of(context)!.listSearch,
+                  ignoreList:
+                      widget.searchIgnoreList ?? currentSelection.keys.toList(),
+                  items: widget.searchOptions ?? [],
+                  resultTileBuilder: widget.searchResultTileBuilder,
+                  elementToString: (String t) => t,
+                  asyncFilteredSearchOptions: widget.loadAsyncSearchOptions,
+                  allowSelectAnyway: widget.allowSelectAnyWay,
+                  searchElementName: widget.searchElementName,
+                ),
+              ),
+            ).then((newName) {
+              setState(() {
+                currentSelection.update(newName, (value) => value,
+                    ifAbsent: () =>
+                        widget.selectionDefaultValue ??
+                        widget.selectionItems[0]);
+              });
+              widget.changedList(currentSelection);
+            });
+          },
+          icon: const Icon(Icons.add),
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        ListTile(
+          title: Text(widget.title),
+          subtitle: Text(
+              "${currentSelection.length} ${AppLocalizations.of(context)!.entries}"),
+          leading: widget.icon,
+          trailing: IconButton(
+            icon: Icon(isExpanded ? Icons.expand_less : Icons.expand_more),
+            onPressed: () {
+              setState(() {
+                isExpanded = !isExpanded;
+              });
+            },
+          ),
+        ),
+        isExpanded
+            ? Padding(
+                padding: EdgeInsets.only(left: widget.columLeftPadding),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: children,
+                ),
+              )
+            : const SizedBox(),
+        const SizedBox(height: distanceDefault),
+      ],
+    );
+  }
+}

--- a/lib/components/content_selection/list_entry.dart
+++ b/lib/components/content_selection/list_entry.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import '../../styling/constants.dart';
+
+class ListEntry<V> extends StatelessWidget {
+  final String labelText;
+  final String name;
+  final V value;
+  final List<V> allValues;
+  final String Function(V value)? valueToString;
+  final DropdownMenuItem<V> Function(V value, String name)?
+      selectValueItemBuilder;
+  final void Function(String name) deleteClicked;
+  final void Function(String name, V value) changedSelection;
+  late final double? selectWidth;
+
+  ListEntry({
+    super.key,
+    required this.labelText,
+    required this.name,
+    required this.value,
+    required this.allValues,
+    required this.deleteClicked,
+    required this.changedSelection,
+    this.valueToString,
+    this.selectValueItemBuilder,
+    double? selectWidthCustom,
+  }) {
+    selectWidth = selectWidthCustom ?? 180;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    assert(selectValueItemBuilder != null || valueToString != null);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: distanceSmall),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            child: Text(
+              "- $name",
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              SizedBox(
+                width: selectWidth,
+                child: DropdownButtonFormField<V>(
+                  value: value,
+                  items: allValues
+                      .map((e) => DropdownMenuItem<V>(
+                            value: e,
+                            child: valueToString != null
+                                ? Text(valueToString!(e))
+                                : selectValueItemBuilder!(e, name),
+                          ))
+                      .toList(),
+                  onChanged: (value) {
+                    changedSelection(name, value as V);
+                  },
+                  decoration: InputDecoration(
+                    contentPadding: const EdgeInsets.only(
+                        left: dropDownVerticalPadding,
+                        right: dropDownVerticalPadding),
+                    labelText: labelText,
+                    border: const OutlineInputBorder(),
+                  ),
+                ),
+              ),
+              IconButton(
+                onPressed: () {
+                  deleteClicked(name);
+                },
+                icon: const Icon(
+                  Icons.delete,
+                  size: iconSizeSmall,
+                  color: negativeColor,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/content_selection/list_entry.dart
+++ b/lib/components/content_selection/list_entry.dart
@@ -1,16 +1,38 @@
 import 'package:flutter/material.dart';
+import 'package:helpwave/components/content_selection/content_selector.dart';
 import '../../styling/constants.dart';
 
+/// The ListEntry used by [ContentSelector]
 class ListEntry<V> extends StatelessWidget {
-  final String labelText;
+  /// Name in front of the entry
   final String name;
+
+  /// The Value of the Entry
   final V value;
-  final List<V> allValues;
+
+  /// The items of the Selection
+  /// IMPORTANT: If omitted or Empty the selection wont be displayed
+  final List<V> items;
+
+  /// The LabelText of the Selection Drop-Down
+  final String labelText;
+
+  /// Maps the value to a displayable String for the Selection
+  /// IMPORTANT: Overwritten by [selectValueItemBuilder]
   final String Function(V value)? valueToString;
+
+  /// A Custom builder for the DropDownItems in the select
+  /// IMPORTANT: Overwrites [valueToString]
   final DropdownMenuItem<V> Function(V value, String name)?
       selectValueItemBuilder;
-  final void Function(String name) deleteClicked;
-  final void Function(String name, V value) changedSelection;
+
+  /// Callback when a Entry is deleted
+  final void Function(String name) onDeleteClicked;
+
+  /// Callback when a Entry's Selection is changed
+  final void Function(String name, V value) onChangedSelection;
+
+  /// The width of the Select
   late final double? selectWidth;
 
   ListEntry({
@@ -18,9 +40,9 @@ class ListEntry<V> extends StatelessWidget {
     required this.labelText,
     required this.name,
     required this.value,
-    required this.allValues,
-    required this.deleteClicked,
-    required this.changedSelection,
+    required this.items,
+    required this.onDeleteClicked,
+    required this.onChangedSelection,
     this.valueToString,
     this.selectValueItemBuilder,
     double? selectWidthCustom,
@@ -30,7 +52,9 @@ class ListEntry<V> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    assert(selectValueItemBuilder != null || valueToString != null);
+    assert(items.isEmpty ||
+        selectValueItemBuilder != null ||
+        valueToString != null);
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: distanceSmall),
       child: Row(
@@ -45,33 +69,35 @@ class ListEntry<V> extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              SizedBox(
-                width: selectWidth,
-                child: DropdownButtonFormField<V>(
-                  value: value,
-                  items: allValues
-                      .map((e) => DropdownMenuItem<V>(
-                            value: e,
-                            child: valueToString != null
-                                ? Text(valueToString!(e))
-                                : selectValueItemBuilder!(e, name),
-                          ))
-                      .toList(),
-                  onChanged: (value) {
-                    changedSelection(name, value as V);
-                  },
-                  decoration: InputDecoration(
-                    contentPadding: const EdgeInsets.only(
-                        left: dropDownVerticalPadding,
-                        right: dropDownVerticalPadding),
-                    labelText: labelText,
-                    border: const OutlineInputBorder(),
-                  ),
-                ),
-              ),
+              items.isNotEmpty
+                  ? SizedBox(
+                      width: selectWidth,
+                      child: DropdownButtonFormField<V>(
+                        value: value,
+                        items: items
+                            .map((e) => DropdownMenuItem<V>(
+                                  value: e,
+                                  child: valueToString != null
+                                      ? Text(valueToString!(e))
+                                      : selectValueItemBuilder!(e, name),
+                                ))
+                            .toList(),
+                        onChanged: (value) {
+                          onChangedSelection(name, value as V);
+                        },
+                        decoration: InputDecoration(
+                          contentPadding: const EdgeInsets.only(
+                              left: dropDownVerticalPadding,
+                              right: dropDownVerticalPadding),
+                          labelText: labelText,
+                          border: const OutlineInputBorder(),
+                        ),
+                      ),
+                    )
+                  : const SizedBox(),
               IconButton(
                 onPressed: () {
-                  deleteClicked(name);
+                  onDeleteClicked(name);
                 },
                 icon: const Icon(
                   Icons.delete,

--- a/lib/components/content_selection/list_entry.dart
+++ b/lib/components/content_selection/list_entry.dart
@@ -35,6 +35,9 @@ class ListEntry<V> extends StatelessWidget {
   /// The width of the Select
   late final double? selectWidth;
 
+  /// Some more Complex Objects cause issues with the native dropDown
+  final bool Function(V value1, V value2)? equalityCheck;
+
   ListEntry({
     super.key,
     required this.labelText,
@@ -46,15 +49,15 @@ class ListEntry<V> extends StatelessWidget {
     this.valueToString,
     this.selectValueItemBuilder,
     double? selectWidthCustom,
+    this.equalityCheck,
   }) {
     selectWidth = selectWidthCustom ?? 180;
   }
 
   @override
   Widget build(BuildContext context) {
-    assert(items.isEmpty ||
-        selectValueItemBuilder != null ||
-        valueToString != null);
+    assert(items.isNotEmpty);
+    assert(selectValueItemBuilder != null || valueToString != null);
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: distanceSmall),
       child: Row(
@@ -73,13 +76,16 @@ class ListEntry<V> extends StatelessWidget {
                   ? SizedBox(
                       width: selectWidth,
                       child: DropdownButtonFormField<V>(
-                        value: value,
+                        value: equalityCheck != null
+                            ? items.firstWhere(
+                                (element) => equalityCheck!(element, value))
+                            : value,
                         items: items
                             .map((e) => DropdownMenuItem<V>(
                                   value: e,
-                                  child: valueToString != null
-                                      ? Text(valueToString!(e))
-                                      : selectValueItemBuilder!(e, name),
+                                  child: selectValueItemBuilder != null
+                                      ? selectValueItemBuilder!(e, name)
+                                      : Text(valueToString!(e)),
                                 ))
                             .toList(),
                         onChanged: (value) {

--- a/lib/components/content_selection/list_search.dart
+++ b/lib/components/content_selection/list_search.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import '../../styling/constants.dart';
+
+class ListSearch<T> extends StatefulWidget {
+  final String title;
+  final List<T> ignoreList;
+  final List<T> items;
+  final Widget Function(BuildContext context, T result)? resultTileBuilder;
+  final Future<List<T>> Function(String searched, List<T> ignoreList)?
+      asyncFilteredSearchOptions;
+  final String Function(T element) elementToString;
+  late final List<T> filteredSearchOptions;
+  final bool allowSelectAnyway;
+  final String? searchElementName;
+
+  ListSearch({
+    super.key,
+    required this.title,
+    required this.resultTileBuilder,
+    required this.elementToString,
+    this.allowSelectAnyway = false,
+    this.ignoreList = const [],
+    this.items = const [],
+    this.asyncFilteredSearchOptions,
+    this.searchElementName,
+  }) {
+    List<T> list = [];
+    list.addAll(items);
+    list.retainWhere((element) => !ignoreList.contains(element));
+    filteredSearchOptions = list;
+  }
+
+  @override
+  State<StatefulWidget> createState() => _ListSearchState<T>();
+}
+
+class _ListSearchState<T> extends State<ListSearch<T>> {
+  final TextEditingController _searchController = TextEditingController();
+
+  // case insensitive search
+  Future<List<T>> getSearchResults(String searched) async {
+    String searchInLower = searched.toLowerCase();
+    List<T> result = [];
+    for (var element in widget.filteredSearchOptions) {
+      if (!widget.filteredSearchOptions.contains(searched) &&
+          widget
+              .elementToString(element)
+              .toLowerCase()
+              .startsWith(searchInLower)) {
+        result.add(element);
+      }
+    }
+    return result;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: SizedBox(
+        height: MediaQuery.of(context).size.height,
+        child: Column(
+          //mainAxisAlignment: MainAxisAlignment.start,
+          //crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: distanceSmall,
+                vertical: distanceDefault,
+              ),
+              child: TextFormField(
+                onChanged: (value) => {setState(() {})},
+                controller: _searchController,
+                decoration: InputDecoration(
+                  suffixIcon: IconButton(
+                    onPressed: () => {
+                      setState(() {
+                        _searchController.clear();
+                      })
+                    },
+                    icon: const Icon(Icons.close),
+                  ),
+                  hintText: AppLocalizations.of(context)!.search,
+                  border: const OutlineInputBorder(),
+                ),
+              ),
+            ),
+            FutureBuilder(
+              future: widget.asyncFilteredSearchOptions != null
+                  ? widget.asyncFilteredSearchOptions!(
+                      _searchController.text, widget.ignoreList)
+                  : getSearchResults(_searchController.text),
+              builder: (context, snapshot) {
+                List<Widget> children = [];
+                if (snapshot.hasData) {
+                  if (snapshot.data!.isNotEmpty) {
+                    if (widget.resultTileBuilder != null) {
+                      children = snapshot.data!
+                          .map((element) =>
+                              widget.resultTileBuilder!(context, element))
+                          .toList();
+                    } else {
+                      children = snapshot.data!.map((element) {
+                        return ListTile(
+                          title: Text(widget.elementToString(element)),
+                          onTap: () {
+                            Navigator.of(context).pop(element);
+                          },
+                        );
+                      }).toList();
+                    }
+                  } else {
+                    children.add(Center(
+                      child: Column(
+                        children: [
+                          const SizedBox(height: distanceBig),
+                          Text(
+                            "${widget.searchElementName ?? _searchController.text} ${AppLocalizations.of(context)!.notFound}",
+                            style: Theme.of(context).textTheme.headline6,
+                          ),
+                          const SizedBox(height: distanceDefault),
+                          widget.allowSelectAnyway
+                              ? TextButton(
+                                  onPressed: () => Navigator.pop(
+                                      context, _searchController.text),
+                                  child: Text(
+                                      "${AppLocalizations.of(context)!.addAnyway}!"),
+                                )
+                              : const SizedBox(),
+                        ],
+                      ),
+                    ));
+                  }
+                } else if (snapshot.hasError) {
+                  children = <Widget>[
+                    Icon(
+                      Icons.error_outline,
+                      color: Theme.of(context).colorScheme.error,
+                      size: iconSizeBig,
+                    ),
+                    const SizedBox(height: distanceBig),
+                    Text('Error: ${snapshot.error}'),
+                  ];
+                }
+                return Expanded(
+                  child: ListView(
+                    children: children,
+                  ),
+                );
+              },
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/content_selection/list_search.dart
+++ b/lib/components/content_selection/list_search.dart
@@ -2,16 +2,41 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../../styling/constants.dart';
 
+/// A customizable Search within a List
+///
+/// Values need to be mapped to String with [elementToString]
+/// Should be used with
+/// [Navigator.push] and [Navigator.pop] with the latter returning the clicked result
 class ListSearch<T> extends StatefulWidget {
+  /// The Title displayed in the AppBar of the Search
   final String title;
+
+  /// The List of SearchItems that should be ignored
   final List<T> ignoreList;
+
+  /// The List of all Items for the Search
   final List<T> items;
+
+  /// Custom builder for displaying a single search result
+  /// IMPORTANT: This disables navigation pops on clicking a result, but can be implemented in the function
+  /// IMPORTANT: Overwrites default display of search results
   final Widget Function(BuildContext context, T result)? resultTileBuilder;
+
+  /// This Function returns the list of search results for [searched]
   final Future<List<T>> Function(String searched, List<T> ignoreList)?
       asyncFilteredSearchOptions;
+
+  /// Maps Elements to String
+  /// Used by default display of search result
   final String Function(T element) elementToString;
+
+  /// The filtered List of search options [items] without [ignoreList]
   late final List<T> filteredSearchOptions;
+
+  /// Allow adding user input not found in the search list
   final bool allowSelectAnyway;
+
+  /// The name of the searched Elements e.g. Medication, Name or Color
   final String? searchElementName;
 
   ListSearch({

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -66,5 +66,6 @@
   "daily3Times": "3x Täglich",
   "daily5Times": "5x Täglich",
   "medicationSearch": "Medikamenten Suche",
-  "listSearch": "Listen-Suche"
+  "listSearch": "Listen-Suche",
+  "list": "Liste"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -65,5 +65,6 @@
   "daily2Times": "2x Täglich",
   "daily3Times": "3x Täglich",
   "daily5Times": "5x Täglich",
-  "medicationSearch": "Medikamenten Suche"
+  "medicationSearch": "Medikamenten Suche",
+  "listSearch": "Listen-Suche"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -65,5 +65,6 @@
   "daily2Times": "2x Daily",
   "daily3Times": "3x Daily",
   "daily5Times": "5x Daily",
-  "medicationSearch": "Medication Search"
+  "medicationSearch": "Medication Search",
+  "listSearch": "List-Search"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -66,5 +66,6 @@
   "daily3Times": "3x Daily",
   "daily5Times": "5x Daily",
   "medicationSearch": "Medication Search",
-  "listSearch": "List-Search"
+  "listSearch": "List-Search",
+  "list": "List"
 }


### PR DESCRIPTION
closes #89 

Test Instructions:
- Test this the code below and add additional parameteres as you like.
```
ContentSelector(
  title: "Weather Stations",
  icon: Icon(Icons.ac_unit),
  selectionItems: [{"weather": "cold"},{"weather": "warm"}, {"weather": "hot"}],
  onChangedList: print,
  valueToString: (value) => value["weather"]!,
  equalityCheck: (value1, value2) => value1["weather"] == value2["weather"],
  loadAsyncSearchOptions: (searched, ignoreList) async {
    String searchInLower = searched.toLowerCase();
    List  <String> result = [];
    List  <String> filteredSearchOptions = ["Louisiana","New York","Tokyo","Berlin"];
    filteredSearchOptions
      .retainWhere((element) => !ignoreList.contains(element));
    for (var element in filteredSearchOptions) {
      if (!filteredSearchOptions.contains(searched) &&
          element.toLowerCase().startsWith(searchInLower)) {
        result.add(element);
      }
    }
    return result;
  },
),
```

Updated wrong code example