### PR TITLE
fix search results being empty for a input containing uppercase

### DIFF
--- a/apps/helpwave/lib/components/content_selection/list_search.dart
+++ b/apps/helpwave/lib/components/content_selection/list_search.dart
@@ -95,6 +95,7 @@ class _ListSearchState<T> extends State<ListSearch<T>> {
     if (widget.filter != null) {
       result = result.where(widget.filter!).toList();
     }
+    searched = searched.toLowerCase();
     result = result
         .where(
           (element) => widget


### PR DESCRIPTION
closes #139

![image](https://user-images.githubusercontent.com/67233923/214141792-f30cecda-f5a4-47fd-9bc1-df0c815b9683.png)
