### PR TITLE
fix: use theme background in unsafe area

### DIFF
--- a/apps/tasks/lib/main.dart
+++ b/apps/tasks/lib/main.dart
@@ -48,8 +48,9 @@ class MyApp extends StatelessWidget {
           ],
           supportedLocales: getSupportedLocals(),
           locale: Locale(languageNotifier.language),
-          home: const SafeArea(
-            child: LoginScreen(),
+          home: Container(
+            color: themeNotifier.getIsDarkNullSafe(context) ? Colors.white10 : Colors.white,
+            child: const SafeArea(child: LoginScreen()),
           ),
         );
       }),


### PR DESCRIPTION
Before and after screenshots included :)

Before
![Simulator Screenshot - iPhone 15 Pro Max - 2023-12-02 at 22 54 27](https://github.com/helpwave/mobile-app/assets/40192999/3eed18a5-f620-4ecb-b739-a18a3f42f10d)

After
![Simulator Screenshot - iPhone 15 Pro Max - 2023-12-02 at 22 54 46](https://github.com/helpwave/mobile-app/assets/40192999/0bd5f889-b2b2-4cc3-ab4c-c156ea2f9e31)