### PR TITLE
Remove WardPatientController from PatientBottomSheet

### DIFF
--- a/apps/tasks/lib/components/patient_bottom_sheet.dart
+++ b/apps/tasks/lib/components/patient_bottom_sheet.dart
@@ -11,7 +11,6 @@ import 'package:provider/provider.dart';
 import 'package:tasks/components/task_bottom_sheet.dart';
 import 'package:tasks/components/task_expansion_tile.dart';
 import 'package:tasks/controllers/patient_controller.dart';
-import 'package:tasks/controllers/ward_patients_controller.dart';
 import 'package:tasks/dataclasses/bed.dart';
 import 'package:tasks/dataclasses/patient.dart';
 import 'package:tasks/dataclasses/room.dart';
@@ -55,9 +54,6 @@ class _PatientBottomSheetState extends State<PatientBottomSheet> {
         ChangeNotifierProvider(
           create: (_) => PatientController(Patient.empty(id: widget.patentId)),
         ),
-        ChangeNotifierProvider(
-          create: (_) => WardPatientsController(),
-        ),
       ],
       child: BottomSheetBase(
         title: Consumer<PatientController>(builder: (context, patientController, _) {
@@ -83,9 +79,9 @@ class _PatientBottomSheetState extends State<PatientBottomSheet> {
         },
         bottomWidget: Padding(
           padding: const EdgeInsets.only(top: paddingMedium),
-          child: Consumer2<PatientController, WardPatientsController>(builder: (context, patientController, wardPatientController, _) {
+          child: Consumer<PatientController>(builder: (context, patientController, _) {
             return LoadingAndErrorWidget(
-                state: wardPatientController.state,
+                state: patientController.state,
                 child: Row(
               mainAxisAlignment: patientController.isCreating ? MainAxisAlignment.end : MainAxisAlignment.spaceBetween,
               children: patientController.isCreating
@@ -122,7 +118,7 @@ class _PatientBottomSheetState extends State<PatientBottomSheet> {
                   width: width * 0.4,
                   child: TextButton(
                     // TODO check whether the patient is active
-                    onPressed: wardPatientController.discharged.contains(patientController.patient)? null : () {
+                    onPressed: patientController.patient.isDischarged ? null : () {
                       showDialog(
                         context: context,
                         builder: (context) => AcceptDialog(titleText: context.localization!.dischargePatient),

--- a/apps/tasks/lib/dataclasses/patient.dart
+++ b/apps/tasks/lib/dataclasses/patient.dart
@@ -48,6 +48,7 @@ class Patient extends PatientMinimal {
   BedMinimal? bed;
   String notes;
   List<Task> tasks;
+  bool isDischarged;
 
   get isUnassigned => bed == null && room == null;
 
@@ -67,7 +68,7 @@ class Patient extends PatientMinimal {
   get doneCount => doneTasks.length;
 
   factory Patient.empty({String id = ""}) {
-    return Patient(id: id, name: "Patient", tasks: [], notes: "");
+    return Patient(id: id, name: "Patient", tasks: [], notes: "", isDischarged: false);
   }
 
   Patient({
@@ -75,6 +76,7 @@ class Patient extends PatientMinimal {
     required super.name,
     required this.tasks,
     required this.notes,
+    required this.isDischarged,
     this.room,
     this.bed,
   });

--- a/apps/tasks/lib/services/patient_svc.dart
+++ b/apps/tasks/lib/services/patient_svc.dart
@@ -40,6 +40,7 @@ class PatientService {
           (patient) => Patient(
             id: patient.id,
             name: patient.humanReadableIdentifier,
+            isDischarged: response.dischargedPatients.contains(patient),
             tasks: patient.tasks
                 .map((task) => Task(
                       id: task.id,
@@ -70,6 +71,7 @@ class PatientService {
           (patient) => Patient(
             id: patient.id,
             name: patient.humanReadableIdentifier,
+            isDischarged: response.dischargedPatients.contains(patient),
             tasks: patient.tasks
                 .map((task) => Task(
                       id: task.id,
@@ -98,6 +100,7 @@ class PatientService {
           (patient) => Patient(
             id: patient.id,
             name: patient.humanReadableIdentifier,
+            isDischarged: true,
             tasks: patient.tasks
                 .map((task) => Task(
                       id: task.id,
@@ -167,6 +170,7 @@ class PatientService {
       id: response.id,
       name: response.humanReadableIdentifier,
       notes: response.notes,
+      isDischarged: response.isDischarged,
       tasks: response.tasks
           .map((task) => Task(
                 id: task.id,


### PR DESCRIPTION
This removes the WardPatientController from the PatientBottomSheet by using the newer PatientDetails API.

Closes issue #510 