### PR TITLE
Issue/500 Null check operator error

### DIFF
--- a/apps/tasks/lib/components/user_bottom_sheet.dart
+++ b/apps/tasks/lib/components/user_bottom_sheet.dart
@@ -81,7 +81,7 @@ class _UserBottomSheetState extends State<UserBottomSheet> {
               return LoadingFutureBuilder(
                   loadingWidget: const SizedBox(),
                   future:
-                      WardService().getWardOverviews(organizationId: currentWardController.currentWard!.organizationId),
+                      WardService().getWardOverviews(organizationId: currentWardController.currentWard?.organizationId),
                   thenWidgetBuilder: (BuildContext context, List<WardOverview> data) {
                     double menuWidth = min(250, width * 0.7);
                     return PopupMenuButton(


### PR DESCRIPTION
The ```currentWard``` is null when the widget is rendered because Navigator.of(context).pushReplacement isnt "awaited".
But since ```organizationId``` can be null we can just use the ? operator on the currentWard.

Closes #500 